### PR TITLE
Update progressive-image.js

### DIFF
--- a/js/progressive-image.js
+++ b/js/progressive-image.js
@@ -38,15 +38,15 @@ if (window.addEventListener && window.requestAnimationFrame && document.getEleme
   function inView() {
 
     if (pItem.length) requestAnimationFrame(function() {
-
-      var wT = window.pageYOffset, wB = wT + window.innerHeight, cRect, pT, pB, p = 0;
+      
+      var wH =  window.innerHeight, cRect, cT, cH, p = 0;
       while (p < pItem.length) {
 
         cRect = pItem[p].getBoundingClientRect();
-        pT = wT + cRect.top;
-        pB = pT + cRect.height;
+        cT = cRect.top;
+        cH = cRect.height;
 
-        if (wT < pB && wB > pT) {
+        if (0 < cT + cH && wH > cT) {
           loadFullImage(pItem[p]);
           pItem[p].classList.remove('replace');
         }


### PR DESCRIPTION
In inView() pageYOffset is not needed, since getBoundingClientRect().top already takes scrolling into account.
Actually the offset was not used anyway, since it was added to both side of the equations in the if condition.