### PR TITLE
Preserve class of preview images

### DIFF
--- a/src/js/progressive-image.js
+++ b/src/js/progressive-image.js
@@ -96,6 +96,9 @@ if (window.addEventListener && window.requestAnimationFrame && document.getEleme
 
         // preview image
         var pImg = item.querySelector && item.querySelector('img.preview');
+        
+        // copy preview image class list
+        var classList = pImg.classList
 
         // add full image
         item.insertBefore(img, pImg && pImg.nextSibling).addEventListener('animationend', function() {
@@ -106,6 +109,9 @@ if (window.addEventListener && window.requestAnimationFrame && document.getEleme
             item.removeChild(pImg);
           }
 
+          // copy the class list of preview to full image
+          img.classList = classList;
+          img.classList.remove('preview');
           img.classList.remove('reveal');
 
         });


### PR DESCRIPTION
I use class names to style the image. I learn that this library will remove the class entirely.

I'm proposing small changes where I copy the class list of the preview image and paste it into the full image so the class list is preserved.

Regards 😊